### PR TITLE
Logging improvement

### DIFF
--- a/ancp/client.py
+++ b/ancp/client.py
@@ -13,6 +13,8 @@ import struct
 import socket
 import logging
 
+log = logging.getLogger(__name__)
+
 
 VERSION_RFC = 50
 
@@ -145,7 +147,6 @@ class Client(object):
 
     def _handle(self):
         """RX / TX Thread"""
-        log = logging.getLogger(__name__)
         while True:
             try:
                 b = self._recvall(4)
@@ -232,7 +233,6 @@ class Client(object):
         return b
 
     def _send_adjac(self, m, code):
-        log = logging.getLogger(__name__)
         log.debug("send adjanecy message with code %s", (code))
         b = self._mkadjac(ADJACENCY, self.timer * 10, m, code)
         self.socket.send(b)
@@ -263,7 +263,6 @@ class Client(object):
                 self._send_syn()
 
     def _handle_syn(self):
-        log = logging.getLogger(__name__)
         log.debug("SYN received with current state %d", self.state)
         if self.state == SYNSENT:
             self._send_synack()
@@ -277,7 +276,6 @@ class Client(object):
             pass
 
     def _handle_synack(self):
-        log = logging.getLogger(__name__)
         log.debug("SYNACK received with current state %d", self.state)
         if self.state == SYNSENT:
             # C !C ??
@@ -292,7 +290,6 @@ class Client(object):
             pass
 
     def _handle_ack(self):
-        log = logging.getLogger(__name__)
         log.debug("ACK received with current state %d", self.state)
         if self.state == ESTAB:
             self._send_ack()
@@ -300,7 +297,6 @@ class Client(object):
             self.state = ESTAB
 
     def _handle_rstack(self):
-        log = logging.getLogger(__name__)
         log.debug("RSTACK received with current state %d", self.state)
         if self.state == SYNSENT:
             pass
@@ -309,7 +305,6 @@ class Client(object):
             self.disconnect(send_ack=True)
 
     def _handle_adjacency(self, var, b):
-        log = logging.getLogger(__name__)
         timer = var >> 8
         m = var & 0x80
         code = var & 0x7f

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -153,19 +153,19 @@ class Client(object):
                 self._handle_timeout()
             else:
                 if len(b) == 0:
-                    log.warning("connection lost with %s " % tomac(self.receiver_name))
+                    log.warning("connection lost with %s ", tomac(self.receiver_name))
                     break
                 else:
-                    log.debug("received len(b) = %d" % len(b))
+                    log.debug("received len(b) = %d", len(b))
                     (id, length) = struct.unpack("!HH", b)
-                    log.debug("message rcvd length field %d" % length)
+                    log.debug("message rcvd length field %d", length)
                     if id != 0x880C:
-                        log.error("incorrect ident 0x%x" % id)
+                        log.error("incorrect ident 0x%x", id)
                         break
                     b = self._recvall(length)
                     if len(b) != length:
                         log.warning("MSG_WAITALL failed")
-                    log.debug("rest received len(b) = %d" % len(b))
+                    log.debug("rest received len(b) = %d", len(b))
                     (ver, mtype, var) = struct.unpack_from("!BBH", b, 0)
                     s0 = self.state
                     if mtype == ADJACENCY:
@@ -180,7 +180,7 @@ class Client(object):
                         self._handle_general(var, b)
                     if s0 != self.state and self.state == ESTAB and not self.established.is_set():
                         self.established.set()
-                        log.info("adjacency established with %s" % tomac(self.receiver_name))
+                        log.info("adjacency established with %s", tomac(self.receiver_name))
         self.established.clear()
 
     def _port_updown(self, message_type, subscriber):
@@ -233,7 +233,7 @@ class Client(object):
 
     def _send_adjac(self, m, code):
         log = logging.getLogger(__name__)
-        log.debug("send adjanecy message with code %s" % (code))
+        log.debug("send adjanecy message with code %s", (code))
         b = self._mkadjac(ADJACENCY, self.timer * 10, m, code)
         self.socket.send(b)
 
@@ -264,7 +264,7 @@ class Client(object):
 
     def _handle_syn(self):
         log = logging.getLogger(__name__)
-        log.debug("SYN received with current state %d" % self.state)
+        log.debug("SYN received with current state %d", self.state)
         if self.state == SYNSENT:
             self._send_synack()
         elif self.state == SYNRCVD:
@@ -278,7 +278,7 @@ class Client(object):
 
     def _handle_synack(self):
         log = logging.getLogger(__name__)
-        log.debug("SYNACK received with current state %d" % self.state)
+        log.debug("SYNACK received with current state %d", self.state)
         if self.state == SYNSENT:
             # C !C ??
             self._send_ack()
@@ -293,7 +293,7 @@ class Client(object):
 
     def _handle_ack(self):
         log = logging.getLogger(__name__)
-        log.debug("ACK received with current state %d" % self.state)
+        log.debug("ACK received with current state %d", self.state)
         if self.state == ESTAB:
             self._send_ack()
         else:
@@ -301,7 +301,7 @@ class Client(object):
 
     def _handle_rstack(self):
         log = logging.getLogger(__name__)
-        log.debug("RSTACK received with current state %d" % self.state)
+        log.debug("RSTACK received with current state %d", self.state)
         if self.state == SYNSENT:
             pass
         else:

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -13,8 +13,6 @@ import struct
 import socket
 import logging
 
-log = logging.getLogger("ancp")
-
 
 VERSION_RFC = 50
 
@@ -147,6 +145,7 @@ class Client(object):
 
     def _handle(self):
         """RX / TX Thread"""
+        log = logging.getLogger(__name__)
         while True:
             try:
                 b = self._recvall(4)
@@ -233,6 +232,7 @@ class Client(object):
         return b
 
     def _send_adjac(self, m, code):
+        log = logging.getLogger(__name__)
         log.debug("send adjanecy message with code %s" % (code))
         b = self._mkadjac(ADJACENCY, self.timer * 10, m, code)
         self.socket.send(b)
@@ -263,6 +263,7 @@ class Client(object):
                 self._send_syn()
 
     def _handle_syn(self):
+        log = logging.getLogger(__name__)
         log.debug("SYN received with current state %d" % self.state)
         if self.state == SYNSENT:
             self._send_synack()
@@ -276,6 +277,7 @@ class Client(object):
             pass
 
     def _handle_synack(self):
+        log = logging.getLogger(__name__)
         log.debug("SYNACK received with current state %d" % self.state)
         if self.state == SYNSENT:
             # C !C ??
@@ -290,6 +292,7 @@ class Client(object):
             pass
 
     def _handle_ack(self):
+        log = logging.getLogger(__name__)
         log.debug("ACK received with current state %d" % self.state)
         if self.state == ESTAB:
             self._send_ack()
@@ -297,6 +300,7 @@ class Client(object):
             self.state = ESTAB
 
     def _handle_rstack(self):
+        log = logging.getLogger(__name__)
         log.debug("RSTACK received with current state %d" % self.state)
         if self.state == SYNSENT:
             pass
@@ -305,6 +309,7 @@ class Client(object):
             self.disconnect(send_ack=True)
 
     def _handle_adjacency(self, var, b):
+        log = logging.getLogger(__name__)
         timer = var >> 8
         m = var & 0x80
         code = var & 0x7f

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -173,9 +173,9 @@ class Client(object):
                     elif mtype == ADJACENCY_UPDATE:
                         self._handle_adjacency_update(var, b)
                     elif mtype == PORT_UP:
-                        pass
+                        log.warning("received port up in AN mode")
                     elif mtype == PORT_DOWN:
-                        pass
+                        log.warning("received port down in AN mode")
                     else:
                         self._handle_general(var, b)
                     if s0 != self.state and self.state == ESTAB and not self.established.is_set():
@@ -315,7 +315,7 @@ class Client(object):
         code = var & 0x7f
         if m == 1:
             # ignore, must be 0 as we are the server
-            pass
+            log.warning("received M flag 1 in AN mode")
         self.receiver_name = struct.unpack_from("!BBBBBB", b, 4)
         self.receiver_instance = struct.unpack_from("!I", b, 24)[0] & 16777215
         if code == SYN:

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -313,9 +313,9 @@ class Client(object):
         timer = var >> 8
         m = var & 0x80
         code = var & 0x7f
-        if m == 1:
-            # ignore, must be 0 as we are the server
-            log.warning("received M flag 1 in AN mode")
+        if m == 0:
+            log.error("received M flag 0 in AN mode")
+            raise RuntimeError("Trying to synchronize with other AN")
         self.receiver_name = struct.unpack_from("!BBBBBB", b, 4)
         self.receiver_instance = struct.unpack_from("!I", b, 24)[0] & 16777215
         if code == SYN:

--- a/ancp/subscriber.py
+++ b/ancp/subscriber.py
@@ -6,9 +6,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import bytes
 import struct
-import logging
-
-log = logging.getLogger("ancp")
 
 # LINE STATE
 SHOWTIME = 1

--- a/ancp/subscriber.py
+++ b/ancp/subscriber.py
@@ -6,6 +6,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import bytes
 import struct
+import logging
+
+log = logging.getLogger(__name__)
 
 # LINE STATE
 SHOWTIME = 1


### PR DESCRIPTION
Next to some changes to logging, an M flag check has been added.

Please double check whether the M flag check is correct. It is supposed to prevent two ANs or two NASs to sync with each other. When the M flag is set wrong a RuntimeError is raised. There might be some better Error to be raised, but I haven't found any.