### PR TITLE
Convert client address-parameters to string

### DIFF
--- a/ancp/client.py
+++ b/ancp/client.py
@@ -94,9 +94,9 @@ class Client(object):
     :type source_address: str
     """
     def __init__(self, address, port=6068, tech_type=TechTypes.DSL, timer=25.0, source_address=None):
-        self.address = address
+        self.address = str(address)
         self.port = port
-        self.source_address = source_address
+        self.source_address = str(source_address) if source_address else None
 
         self.timer = timer  # adjacency timer
         self.timeout = 1.0  # socket timeout


### PR DESCRIPTION
Converting the address parameters to string will make it possible for
netaddr.IPAddress or ipaddress.IPAddress to be passed as parameters.