### PR TITLE
Fix collections iterable issue in python 3 10

### DIFF
--- a/ancp/client.py
+++ b/ancp/client.py
@@ -14,6 +14,11 @@ import socket
 import logging
 import collections
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 log = logging.getLogger(__name__)
 
 
@@ -173,7 +178,7 @@ class Client(object):
         :param subscriber: collection of ANCP subscribers
         :type subscriber: [ancp.subscriber.Subscriber]
         """
-        if not isinstance(subscribers, collections.Iterable):
+        if not isinstance(subscribers, Iterable):
             subscribers = [subscribers]
         elif len(subscribers) == 0:
             raise ValueError("No Subscribers passed")
@@ -187,7 +192,7 @@ class Client(object):
         :param subscriber: collection of ANCP subscribers
         :type subscriber: [ancp.subscriber.Subscriber]
         """
-        if not isinstance(subscribers, collections.Iterable):
+        if not isinstance(subscribers, Iterable):
             subscribers = [subscribers]
         elif len(subscribers) == 0:
             raise ValueError("No Subscribers passed")

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -12,7 +12,6 @@ from threading import Thread, Event, Lock
 import struct
 import socket
 import logging
-# import collections
 
 try:
     from collections.abc import Iterable

--- a/ancp/client.py
+++ b/ancp/client.py
@@ -12,7 +12,7 @@ from threading import Thread, Event, Lock
 import struct
 import socket
 import logging
-import collections
+# import collections
 
 try:
     from collections.abc import Iterable


### PR DESCRIPTION
Christian, 
there was an issue with pyANCP in python 3.10:

The Iterable abstract class was removed from collections in Python 3.10. See the deprecation note in the 3.9 [collections docs](https://docs.python.org/3.9/library/collections.html). In the section [Removed](https://docs.python.org/3/whatsnew/3.10.html#removed) of the 3.10 docs, the item 
Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the collections module. (Contributed by Victor Stinner in bpo-37324.)

Please consider tho PR to fix the issue.
Stefan